### PR TITLE
Build/run fixes for linux.

### DIFF
--- a/SS14.Client.Services/Configuration/ConfigurationManager.cs
+++ b/SS14.Client.Services/Configuration/ConfigurationManager.cs
@@ -21,6 +21,19 @@ namespace SS14.Client.Services.Configuration
                 var config = (Configuration) configLoader.Deserialize(configReader);
                 configReader.Close();
                 Configuration = config;
+
+                // sanitize the pathname in config.xml for the current OS
+                // N.B.: You cannot use Path.DirectorySeparatorChar and
+                // Path.AltDirectorySeparatorChar here, because on some platforms
+                // they are the same.  Mono/linux has both as '/', for example.
+                // Hardcode the only platforms we care about.
+                // FIXME: Move this into SS14.Shared.PlatformIndependant or similar.
+
+                var separators = new char [] { '/', '\\' };
+                string newpath = "";
+                foreach (string tmp in config.ResourcePack.Split(separators))
+                    newpath = Path.Combine (newpath, tmp);
+                config.ResourcePack = newpath;
             }
             else
             {

--- a/SS14.Client.Services/prebuild.xml
+++ b/SS14.Client.Services/prebuild.xml
@@ -43,6 +43,7 @@
 
     <File buildAction="Compile">Lighting/QuadRenderer.cs</File>
     <File buildAction="Compile">Lighting/ShadowMapResolver.cs</File>
+    <File buildAction="Compile">Lighting/ShadowmapSize.cs</File>
  
     <File buildAction="Compile">Map/MapManager.cs</File>
     <File buildAction="Compile">MessageLogging/MessageLogger.cs</File>

--- a/SS14.Client/Program.cs
+++ b/SS14.Client/Program.cs
@@ -1,4 +1,5 @@
 ﻿using SS14.Shared.Minidump;
+using SS14.Shared.Utility;
 using System;
 using System.Windows.Forms;
 
@@ -18,7 +19,7 @@ namespace SS14.Client
             //Process command-line args
             processArgs(args);
             //Register minidump dumper only if the app isn't being debugged. No use filling up hard drives with shite
-            if (!System.Diagnostics.Debugger.IsAttached)
+            if (PlatformDetector.DetectPlatform() == Platform.Windows && !System.Diagnostics.Debugger.IsAttached)
                 MiniDump.Register("crashdump-" + Guid.NewGuid().ToString("N") + ".dmp",
                                   fullDump
                                       ? MiniDump.MINIDUMP_TYPE.MiniDumpWithFullMemory

--- a/SS14.Client/prebuild.xml
+++ b/SS14.Client/prebuild.xml
@@ -21,6 +21,7 @@
   <Reference name="System.Windows.Forms"/>
   <Files>
     <File buildAction="Compile" subType="Form">MainWindow.cs</File>
+    <File buildAction="Compile">GameController.cs</File>
     <File buildAction="Compile">MainWindow.Designer.cs</File>
     <!--<File buildAction="EmbeddedResource">MainWindow.resx</File>-->
     <File buildAction="Compile">Program.cs</File>


### PR DESCRIPTION
Linux/monodevelop, with these changes I can run the client to the same point as the VS2013 version on windows.
